### PR TITLE
Updated travis.yml to run powershell

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,13 +11,16 @@ matrix:
     - bash linux_mac/magpi-issue-downloader_spanish.sh
     - bash linux_mac/magpi-special-issue-downloader.sh
   - language: csharp
+    services:
+      - docker
+      # Replace with your image name.
     before_script:
-      - chmod +x ./windows/*.ps1
-    script:
-    - ./windows/magpi-education-downloader.ps1
-    - ./windows/magpi-issue-downloader.ps1
-    - ./windows/magpi-issue-downloader_french.ps1
-    - ./windows/magpi-issue-downloader_hebrew.ps1
-    - ./windows/magpi-issue-downloader_italian.ps1
-    - ./windows/magpi-issue-downloader_spanish.ps1
-    - ./windows/magpi-special-issue-downloader.ps1
+      - docker pull microsoft/powershell
+      - docker run -v ./windows:/data microsoft/powershell /bin/sh -c "cd /data; ./windows/magpi-education-downloader.ps1"
+      - docker run -v ./windows:/data microsoft/powershell /bin/sh -c "cd /data; ./windows/magpi-issue-downloader.ps1"
+      - docker run -v ./windows:/data microsoft/powershell /bin/sh -c "cd /data; ./windows/magpi-issue-downloader_french.ps1"
+      - docker run -v ./windows:/data microsoft/powershell /bin/sh -c "cd /data; ./windows/magpi-issue-downloader_hebrew.ps1"
+      - docker run -v ./windows:/data microsoft/powershell /bin/sh -c "cd /data; ./windows/magpi-issue-downloader_italian.ps1"
+      - docker run -v ./windows:/data microsoft/powershell /bin/sh -c "cd /data; ./windows/magpi-issue-downloader_spanish.ps1"
+      - docker run -v ./windows:/data microsoft/powershell /bin/sh -c "cd /data; ./windows/magpi-special-issue-downloader.ps1"
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,21 @@
-language: bash
-
-script:
-- bash linux_mac/magpi-education-downloader.sh
-- bash linux_mac/magpi-issue-downloader.sh
-- bash linux_mac/magpi-issue-downloader.sh -f 60 -l 62
-- bash linux_mac/magpi-issue-downloader_french.sh
-- bash linux_mac/magpi-issue-downloader_hebrew.sh
-- bash linux_mac/magpi-issue-downloader_italian.sh
-- bash linux_mac/magpi-issue-downloader_spanish.sh
-- bash linux_mac/magpi-special-issue-downloader.sh
+matrix:
+  include:
+  - language: bash
+    script:
+    - bash linux_mac/magpi-education-downloader.sh
+    - bash linux_mac/magpi-issue-downloader.sh
+    - bash linux_mac/magpi-issue-downloader.sh -f 60 -l 62
+    - bash linux_mac/magpi-issue-downloader_french.sh
+    - bash linux_mac/magpi-issue-downloader_hebrew.sh
+    - bash linux_mac/magpi-issue-downloader_italian.sh
+    - bash linux_mac/magpi-issue-downloader_spanish.sh
+    - bash linux_mac/magpi-special-issue-downloader.sh
+  - language: cpp
+    script:
+    - ./windows/magpi-education-downloader.ps1
+    - ./windows/magpi-issue-downloader.ps1
+    - ./windows/magpi-issue-downloader_french.ps1
+    - ./windows/magpi-issue-downloader_hebrew.ps1
+    - ./windows/magpi-issue-downloader_italian.ps1
+    - ./windows/magpi-issue-downloader_spanish.ps1
+    - ./windows/magpi-special-issue-downloader.ps1

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,9 @@ matrix:
     - bash linux_mac/magpi-issue-downloader_italian.sh
     - bash linux_mac/magpi-issue-downloader_spanish.sh
     - bash linux_mac/magpi-special-issue-downloader.sh
-  - language: cpp
+  - language: csharp
+    before_script:
+      - chmod +x *.ps1
     script:
     - ./windows/magpi-education-downloader.ps1
     - ./windows/magpi-issue-downloader.ps1

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,11 +16,11 @@ matrix:
       # Replace with your image name.
     before_script:
       - docker pull microsoft/powershell
-      - docker run -v ./windows:/data microsoft/powershell /bin/sh -c "cd /data; ./windows/magpi-education-downloader.ps1"
-      - docker run -v ./windows:/data microsoft/powershell /bin/sh -c "cd /data; ./windows/magpi-issue-downloader.ps1"
-      - docker run -v ./windows:/data microsoft/powershell /bin/sh -c "cd /data; ./windows/magpi-issue-downloader_french.ps1"
-      - docker run -v ./windows:/data microsoft/powershell /bin/sh -c "cd /data; ./windows/magpi-issue-downloader_hebrew.ps1"
-      - docker run -v ./windows:/data microsoft/powershell /bin/sh -c "cd /data; ./windows/magpi-issue-downloader_italian.ps1"
-      - docker run -v ./windows:/data microsoft/powershell /bin/sh -c "cd /data; ./windows/magpi-issue-downloader_spanish.ps1"
-      - docker run -v ./windows:/data microsoft/powershell /bin/sh -c "cd /data; ./windows/magpi-special-issue-downloader.ps1"
+      - docker run -v $(pwd)/windows:/data microsoft/powershell /bin/sh -c "cd /data; chmod +x *.ps1; powershell ./magpi-education-downloader.ps1"
+      - docker run -v $(pwd)/windows:/data microsoft/powershell /bin/sh -c "cd /data; chmod +x *.ps1; powershell ./magpi-issue-downloader.ps1"
+      - docker run -v $(pwd)/windows:/data microsoft/powershell /bin/sh -c "cd /data; chmod +x *.ps1; powershell ./magpi-issue-downloader_french.ps1"
+      - docker run -v $(pwd)/windows:/data microsoft/powershell /bin/sh -c "cd /data; chmod +x *.ps1; powershell ./magpi-issue-downloader_hebrew.ps1"
+      - docker run -v $(pwd)/windows:/data microsoft/powershell /bin/sh -c "cd /data; chmod +x *.ps1; powershell ./magpi-issue-downloader_italian.ps1"
+      - docker run -v $(pwd)/windows:/data microsoft/powershell /bin/sh -c "cd /data; chmod +x *.ps1; powershell ./magpi-issue-downloader_spanish.ps1"
+      - docker run -v $(pwd)/windows:/data microsoft/powershell /bin/sh -c "cd /data; chmod +x *.ps1; powershell ./magpi-special-issue-downloader.ps1"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,17 +10,18 @@ matrix:
     - bash linux_mac/magpi-issue-downloader_italian.sh
     - bash linux_mac/magpi-issue-downloader_spanish.sh
     - bash linux_mac/magpi-special-issue-downloader.sh
-  - language: csharp
+  - language: bash
     services:
       - docker
       # Replace with your image name.
     before_script:
       - docker pull microsoft/powershell
       - docker run -v $(pwd)/windows:/data microsoft/powershell /bin/sh -c "cd /data; chmod +x *.ps1; powershell ./magpi-education-downloader.ps1"
-      - docker run -v $(pwd)/windows:/data microsoft/powershell /bin/sh -c "cd /data; chmod +x *.ps1; powershell ./magpi-issue-downloader.ps1"
+      #- docker run -v $(pwd)/windows:/data microsoft/powershell /bin/sh -c "cd /data; chmod +x *.ps1; powershell ./magpi-issue-downloader.ps1"
       - docker run -v $(pwd)/windows:/data microsoft/powershell /bin/sh -c "cd /data; chmod +x *.ps1; powershell ./magpi-issue-downloader_french.ps1"
       - docker run -v $(pwd)/windows:/data microsoft/powershell /bin/sh -c "cd /data; chmod +x *.ps1; powershell ./magpi-issue-downloader_hebrew.ps1"
       - docker run -v $(pwd)/windows:/data microsoft/powershell /bin/sh -c "cd /data; chmod +x *.ps1; powershell ./magpi-issue-downloader_italian.ps1"
       - docker run -v $(pwd)/windows:/data microsoft/powershell /bin/sh -c "cd /data; chmod +x *.ps1; powershell ./magpi-issue-downloader_spanish.ps1"
       - docker run -v $(pwd)/windows:/data microsoft/powershell /bin/sh -c "cd /data; chmod +x *.ps1; powershell ./magpi-special-issue-downloader.ps1"
+      - ls $(pwd)/windows
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
     - bash linux_mac/magpi-special-issue-downloader.sh
   - language: csharp
     before_script:
-      - chmod +x *.ps1
+      - chmod +x ./windows/*.ps1
     script:
     - ./windows/magpi-education-downloader.ps1
     - ./windows/magpi-issue-downloader.ps1

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ matrix:
     script:
       - docker pull microsoft/powershell
       - docker run -v $(pwd)/windows:/data microsoft/powershell /bin/sh -c "cd /data; chmod +x *.ps1; powershell ./magpi-education-downloader.ps1"
-      #- docker run -v $(pwd)/windows:/data microsoft/powershell /bin/sh -c "cd /data; chmod +x *.ps1; powershell ./magpi-issue-downloader.ps1"
+      - docker run -v $(pwd)/windows:/data microsoft/powershell /bin/sh -c "cd /data; chmod +x *.ps1; powershell ./magpi-issue-downloader.ps1"
       - docker run -v $(pwd)/windows:/data microsoft/powershell /bin/sh -c "cd /data; chmod +x *.ps1; powershell ./magpi-issue-downloader_french.ps1"
       - docker run -v $(pwd)/windows:/data microsoft/powershell /bin/sh -c "cd /data; chmod +x *.ps1; powershell ./magpi-issue-downloader_hebrew.ps1"
       - docker run -v $(pwd)/windows:/data microsoft/powershell /bin/sh -c "cd /data; chmod +x *.ps1; powershell ./magpi-issue-downloader_italian.ps1"

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
     services:
       - docker
       # Replace with your image name.
-    before_script:
+    script:
       - docker pull microsoft/powershell
       - docker run -v $(pwd)/windows:/data microsoft/powershell /bin/sh -c "cd /data; chmod +x *.ps1; powershell ./magpi-education-downloader.ps1"
       #- docker run -v $(pwd)/windows:/data microsoft/powershell /bin/sh -c "cd /data; chmod +x *.ps1; powershell ./magpi-issue-downloader.ps1"
@@ -23,5 +23,4 @@ matrix:
       - docker run -v $(pwd)/windows:/data microsoft/powershell /bin/sh -c "cd /data; chmod +x *.ps1; powershell ./magpi-issue-downloader_italian.ps1"
       - docker run -v $(pwd)/windows:/data microsoft/powershell /bin/sh -c "cd /data; chmod +x *.ps1; powershell ./magpi-issue-downloader_spanish.ps1"
       - docker run -v $(pwd)/windows:/data microsoft/powershell /bin/sh -c "cd /data; chmod +x *.ps1; powershell ./magpi-special-issue-downloader.ps1"
-      - ls $(pwd)/windows
 


### PR DESCRIPTION
After several test and with lots of try/error commits , i've setted a travis.yml file that will run bash and powershell scripts. 
For the powershell scripts i'm using the official powershell docker image. I've disabled the magpi-issue-downloader.ps1 test to avoid a long wait since this script it will download all issues of magazine.

this pull request is a possible solution for issue #8 