### PR TITLE
Switch magpi-issue-downloader.sh to main branch of downloader.sh; solves problem with new links

### DIFF
--- a/linux_mac/magpi-issue-downloader.sh
+++ b/linux_mac/magpi-issue-downloader.sh
@@ -27,7 +27,7 @@ recentIssue=$(cat "$file");
 # workaround for a known limitation in bash 3.x: http://lists.gnu.org/archive/html/bug-bash/2006-01/msg00018.html
 # stackoverflow: https://stackoverflow.com/questions/32596123/why-source-command-doesnt-work-with-process-substitution-in-bash-3-2/32596626#32596626
 # shellcheck disable=SC1091
-source /dev/stdin <<<"$(curl -s https://raw.githubusercontent.com/joergi/downloader/0.3.0/linux_mac/downloader.sh)" "$downloadUrl" "$OUTDIR" "$recentIssue" "$@"
+source /dev/stdin <<<"$(curl -s https://raw.githubusercontent.com/joergi/downloader/main/linux_mac/downloader.sh)" "$downloadUrl" "$OUTDIR" "$recentIssue" "$@"
 
 
 exit 0


### PR DESCRIPTION
Change downloader.sh link to reflect [recent commit for handling new download links](https://github.com/joergi/downloader/pull/12#issue-563461831).