### PR TITLE
Switch magpi-special-issue-downloader.sh to main branch of downloader.sh

### DIFF
--- a/linux_mac/magpi-special-issue-downloader.sh
+++ b/linux_mac/magpi-special-issue-downloader.sh
@@ -21,7 +21,7 @@ fi
 file=$BASEDIR"/sources-for-download/special-issues.txt"
 while IFS= read -r line
 do
-	bash <(curl https://raw.githubusercontent.com/joergi/downloader/0.3.0/linux_mac/downloader.sh) "$line" "$OUTDIR"
+	bash <(curl https://raw.githubusercontent.com/joergi/downloader/main/linux_mac/downloader.sh) "$line" "$OUTDIR"
 done < "$file"
 
 exit 0


### PR DESCRIPTION
Changed downloader.sh link to reflect [recent commit for handling new download links](https://github.com/joergi/downloader/pull/12#issue-563461831).

Both bash scripts using downloader.sh in this repo were using the tagged 0.3.0 version which is now outdated (and wasn't working for me, hence the pull requests to solve the issue).