### PR TITLE
Allow user to specify UID:GID with PUID:PGID

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,43 +1,11 @@
-# Stage 1: Build stage
-FROM alpine:latest as builder
+FROM alpine:latest
 
-# hadolint disable=DL3018
-ARG UID=1000
-ARG GID=1000
-
-RUN addgroup -g ${GID} myuser && adduser -u ${UID} -G myuser -D myuser
-
-RUN apk update && apk add --no-cache sudo
-
-RUN echo "myuser ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
-
-USER myuser
-
-RUN sudo apk add --no-cache wget bash curl sed grep
+RUN apk add --no-cache su-exec curl wget bash
 
 COPY sources-for-download /app/sources-for-download
-
-# Stage 2: Final stage
-#FROM alpine:latest
-FROM ubuntu:latest
-
-ARG UID=1000
-ARG GID=1000
-
-RUN groupadd -g ${GID} myuser && useradd -u ${UID} -g myuser -m myuser
-RUN apt-get update && apt-get install -y curl wget
-
-# Create the 'issues' directory with desired ownership inside the container
-RUN mkdir -p /app/issues \
-    && chown -R myuser:myuser /app/issues
-
-COPY --from=builder /app/sources-for-download /app/sources-for-download
 COPY linux_mac /app/linux_mac
-RUN chown -R myuser:myuser /app/linux_mac
+COPY --chmod=755 entrypoint.sh /app/entrypoint.sh
 
-COPY entrypoint.sh /app/entrypoint.sh
-RUN chmod +x /app/entrypoint.sh
-
-USER myuser
+VOLUME /app/issues
 
 ENTRYPOINT ["/bin/sh", "/app/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,3 +1,20 @@
-#!/bin/bash
+#!/bin/sh
+
+set -e
+
+# Default to 1000:1000 as per the original behaviour.
+export PUID=${PUID:-1000}
+export PGID=${PGID:-1000}
 export IS_DOCKER=true
-bash /app/linux_mac/magpi-issue-downloader.sh "$@"
+
+# Set privileges for /app/issues but only if pid 1 user is root and we are dropping privileges.
+# If container is run as an unprivileged user, it means owner already handled ownership setup on their own.
+# Running chown in that case (as non-root) will cause error
+[ "$(id -u)" == "0" ] && [ "${PUID}" != "0" ] && chown -R ${PUID}:${PGID} /app/issues
+
+# Drop privileges (when asked to) if root, otherwise run as current user
+if [ "$(id -u)" == "0" ] && [ "${PUID}" != "0" ]; then
+    su-exec ${PUID}:${PGID} bash /app/linux_mac/magpi-issue-downloader.sh "$@"
+else
+    exec bash /app/linux_mac/magpi-issue-downloader.sh "$@"
+fi


### PR DESCRIPTION
The original Dockerfile hardcodes UID and GID, causing annoyances for anyone not running as 1000:1000. This commit reworks the Dockerfile while also allowing the user to specify the desired UID and GID via the PUID and PGID environment variables.